### PR TITLE
fix: when undotree is empty

### DIFF
--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -48,7 +48,7 @@ local function init()
         callback = function()
             --  2 * (total - id) + 1 = line
             local id_under_cursor = _tree.total - (api.nvim_win_get_cursor(_tree_win)[1] - 1) / 2
-            if id_under_cursor % 1 == 0 then -- integer
+            if _tree.total ~= 0 and id_under_cursor % 1 == 0 then -- integer
                 local before_ctx = diff.get_context(M.attach_buf, id_under_cursor - 1)
                 local cur_ctx = diff.get_context(M.attach_buf, id_under_cursor)
                 local diff_ctx = diff.get_diff(before_ctx, cur_ctx)


### PR DESCRIPTION
`nvim --headless --clean --cmd "se rtp^=." +'lua require("atone").setup{}' +'lua vim.defer_fn(function() vim.cmd.Atone("toggle") end, 10)' README.md`
```
Error in CursorMoved Autocommands for "<buffer=2>":
Lua callback: ./lua/atone/diff.lua:26: Lua: /usr/share/nvim/runtime/lua/vim/_editor.lua:375: CursorMoved Autocommands for "<buffer=2>"..script nvim_exec2() called at CursorMo
ved Autocommands for "<buffer=2>":0, line 1: Vim(rundo):E822: Cannot open undo file for reading: /home/phan/.cache/nvim/atone-undo.undo
stack traceback:
        [C]: in function 'nvim_exec2'
        /usr/share/nvim/runtime/lua/vim/_editor.lua:375: in function 'cmd'
        ./lua/atone/diff.lua:27: in function <./lua/atone/diff.lua:26>
        [C]: in function 'nvim_buf_call'
        ./lua/atone/diff.lua:26: in function 'get_context'
        ./lua/atone/core.lua:53: in function <./lua/atone/core.lua:48>
stack traceback:
        [C]: in function 'nvim_buf_call'
        ./lua/atone/diff.lua:26: in function 'get_context'
        ./lua/atone/core.lua:53: in function <./lua/atone/core.lua:48>

```
