### PR TITLE
feat: add undo/redo step actions for the diff window

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ require("atone").setup({
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
-            undo_step_back = "u",
-            undo_step_forward = "<C-r>",
+            undo = "u",
+            redo = "<C-r>",
         },
         help = {
             quit_help = { "<C-c>", "q" },
@@ -242,8 +242,8 @@ Here are the available actions and their default keybindings:
 | `delete_all_marks` | `dM`      | Delete all marks in current buffer.                             |
 | `goto_mark`   | `'`, `` ` ``   | Jump to a mark slot (0-9).                                      |
 | `mark_picker` | `s`            | Open mark picker (fuzzy find).                                  |
-| `undo_step_back`    | `u` (diff window)      | Undo one step in the attached buffer.                        |
-| `undo_step_forward` | `<C-r>` (diff window)  | Redo one step in the attached buffer.                        |
+| `undo`    | `u` (diff window)      | Undo one step in the attached buffer.                        |
+| `redo` | `<C-r>` (diff window)  | Redo one step in the attached buffer.                        |
 | `quit`        | `<C-c>`, `q`   | Close all `atone.nvim` windows (tree, diff, and help).          |
 | `help`        | `?`, `g?`      | Show the help page.                                             |
 | `quit_help`   | `<C-c>`, `q`   | Close the help window.                                          |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ require("atone").setup({
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
+            undo_step_back = "u",
+            undo_step_forward = "<C-r>",
         },
         help = {
             quit_help = { "<C-c>", "q" },
@@ -240,6 +242,8 @@ Here are the available actions and their default keybindings:
 | `delete_all_marks` | `dM`      | Delete all marks in current buffer.                             |
 | `goto_mark`   | `'`, `` ` ``   | Jump to a mark slot (0-9).                                      |
 | `mark_picker` | `s`            | Open mark picker (fuzzy find).                                  |
+| `undo_step_back`    | `u` (diff window)      | Undo one step in the attached buffer.                        |
+| `undo_step_forward` | `<C-r>` (diff window)  | Redo one step in the attached buffer.                        |
 | `quit`        | `<C-c>`, `q`   | Close all `atone.nvim` windows (tree, diff, and help).          |
 | `help`        | `?`, `g?`      | Show the help page.                                             |
 | `quit_help`   | `<C-c>`, `q`   | Close the help window.                                          |

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -56,8 +56,8 @@ M.opts = {
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
-            undo_step_back = "u",
-            undo_step_forward = "<C-r>",
+            undo = "u",
+            redo = "<C-r>",
         },
         help = {
             quit_help = { "<C-c>", "q" },

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -56,6 +56,8 @@ M.opts = {
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
+            undo_step_back = "u",
+            undo_step_forward = "<C-r>",
         },
         help = {
             quit_help = { "<C-c>", "q" },

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -224,11 +224,8 @@ local mappings = {
         end,
         "Open mark picker",
     },
-    undo_step_back = {
+    undo = {
         function()
-            if not M.attach_buf then
-                return
-            end
             api.nvim_buf_call(M.attach_buf, function()
                 vim.cmd("silent undo")
             end)
@@ -236,11 +233,8 @@ local mappings = {
         end,
         "Undo one step in the attached buffer",
     },
-    undo_step_forward = {
+    redo = {
         function()
-            if not M.attach_buf then
-                return
-            end
             api.nvim_buf_call(M.attach_buf, function()
                 vim.cmd("silent redo")
             end)

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -224,6 +224,30 @@ local mappings = {
         end,
         "Open mark picker",
     },
+    undo_step_back = {
+        function()
+            if not M.attach_buf then
+                return
+            end
+            api.nvim_buf_call(M.attach_buf, function()
+                vim.cmd("silent undo")
+            end)
+            M.refresh()
+        end,
+        "Undo one step in the attached buffer",
+    },
+    undo_step_forward = {
+        function()
+            if not M.attach_buf then
+                return
+            end
+            api.nvim_buf_call(M.attach_buf, function()
+                vim.cmd("silent redo")
+            end)
+            M.refresh()
+        end,
+        "Redo one step in the attached buffer",
+    },
 }
 
 --- Update the diff display buffer and apply the extra diff preview layers.

--- a/tests/undo_step_spec.lua
+++ b/tests/undo_step_spec.lua
@@ -64,8 +64,12 @@ describe("undo / redo", function()
             local keymaps = api.nvim_buf_get_keymap(core._auto_diff_buf, "n")
             local fn_undo, fn_redo
             for _, km in ipairs(keymaps) do
-                if km.lhs == "u" then fn_undo = km.callback end
-                if km.lhs == "<C-r>" or km.lhs == "<C-R>" then fn_redo = km.callback end
+                if km.lhs == "u" then
+                    fn_undo = km.callback
+                end
+                if km.lhs == "<C-r>" or km.lhs == "<C-R>" then
+                    fn_redo = km.callback
+                end
             end
             assert.is_not_nil(fn_redo, "<C-r> keymap should be set on auto_diff_buf")
 

--- a/tests/undo_step_spec.lua
+++ b/tests/undo_step_spec.lua
@@ -18,7 +18,7 @@ local function make_buf_with_history()
     return buf
 end
 
-describe("undo_step_back / undo_step_forward", function()
+describe("undo / redo", function()
     before_each(function()
         atone.setup({ diff_cur_node = { enabled = false } })
     end)
@@ -29,13 +29,13 @@ describe("undo_step_back / undo_step_forward", function()
         end
     end)
 
-    it("undo_step_back reverts one step in the attached buffer", function()
+    it("undo reverts one step in the attached buffer", function()
         local buf = make_buf_with_history()
         api.nvim_buf_call(buf, function()
             core.open()
             assert.are.same({ "edit 2" }, api.nvim_buf_get_lines(buf, 0, -1, false))
 
-            -- trigger undo_step_back via the buffer-local keymap on _auto_diff_buf
+            -- trigger undo via the buffer-local keymap on _auto_diff_buf
             local keymaps = api.nvim_buf_get_keymap(core._auto_diff_buf, "n")
             local fn_undo
             for _, km in ipairs(keymaps) do
@@ -52,7 +52,7 @@ describe("undo_step_back / undo_step_forward", function()
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("undo_step_forward re-applies a reverted step", function()
+    it("redo re-applies a reverted step", function()
         local buf = make_buf_with_history()
         api.nvim_buf_call(buf, function()
             core.open()
@@ -75,7 +75,7 @@ describe("undo_step_back / undo_step_forward", function()
     end)
 
     it("default keymaps are u and <C-r>", function()
-        assert.are.equal("u", config.opts.keymaps.auto_diff.undo_step_back)
-        assert.are.equal("<C-r>", config.opts.keymaps.auto_diff.undo_step_forward)
+        assert.are.equal("u", config.opts.keymaps.auto_diff.undo)
+        assert.are.equal("<C-r>", config.opts.keymaps.auto_diff.redo)
     end)
 end)

--- a/tests/undo_step_spec.lua
+++ b/tests/undo_step_spec.lua
@@ -1,0 +1,81 @@
+---@diagnostic disable: undefined-global, undefined-field
+local atone = require("atone")
+local core = require("atone.core")
+local config = require("atone.config")
+local api = vim.api
+
+local function make_buf_with_history()
+    local buf = api.nvim_create_buf(false, true)
+    vim.bo[buf].buftype = ""
+    vim.bo[buf].modifiable = true
+    vim.bo[buf].swapfile = false
+    vim.bo[buf].undolevels = 64
+    api.nvim_buf_set_lines(buf, 0, -1, false, { "original" })
+    vim.o.undolevels = vim.o.undolevels -- force undo break
+    api.nvim_buf_set_lines(buf, 0, -1, false, { "edit 1" })
+    vim.o.undolevels = vim.o.undolevels
+    api.nvim_buf_set_lines(buf, 0, -1, false, { "edit 2" })
+    return buf
+end
+
+describe("undo_step_back / undo_step_forward", function()
+    before_each(function()
+        atone.setup({ diff_cur_node = { enabled = false } })
+    end)
+
+    after_each(function()
+        if core._show then
+            core.close()
+        end
+    end)
+
+    it("undo_step_back reverts one step in the attached buffer", function()
+        local buf = make_buf_with_history()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            assert.are.same({ "edit 2" }, api.nvim_buf_get_lines(buf, 0, -1, false))
+
+            -- trigger undo_step_back via the buffer-local keymap on _auto_diff_buf
+            local keymaps = api.nvim_buf_get_keymap(core._auto_diff_buf, "n")
+            local fn_undo
+            for _, km in ipairs(keymaps) do
+                if km.lhs == "u" then
+                    fn_undo = km.callback
+                    break
+                end
+            end
+            assert.is_not_nil(fn_undo, "u keymap should be set on auto_diff_buf")
+            fn_undo()
+
+            assert.are.same({ "edit 1" }, api.nvim_buf_get_lines(buf, 0, -1, false))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("undo_step_forward re-applies a reverted step", function()
+        local buf = make_buf_with_history()
+        api.nvim_buf_call(buf, function()
+            core.open()
+
+            local keymaps = api.nvim_buf_get_keymap(core._auto_diff_buf, "n")
+            local fn_undo, fn_redo
+            for _, km in ipairs(keymaps) do
+                if km.lhs == "u" then fn_undo = km.callback end
+                if km.lhs == "<C-r>" then fn_redo = km.callback end
+            end
+            assert.is_not_nil(fn_redo, "<C-r> keymap should be set on auto_diff_buf")
+
+            fn_undo()
+            assert.are.same({ "edit 1" }, api.nvim_buf_get_lines(buf, 0, -1, false))
+
+            fn_redo()
+            assert.are.same({ "edit 2" }, api.nvim_buf_get_lines(buf, 0, -1, false))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("default keymaps are u and <C-r>", function()
+        assert.are.equal("u", config.opts.keymaps.auto_diff.undo_step_back)
+        assert.are.equal("<C-r>", config.opts.keymaps.auto_diff.undo_step_forward)
+    end)
+end)

--- a/tests/undo_step_spec.lua
+++ b/tests/undo_step_spec.lua
@@ -11,9 +11,13 @@ local function make_buf_with_history()
     vim.bo[buf].swapfile = false
     vim.bo[buf].undolevels = 64
     api.nvim_buf_set_lines(buf, 0, -1, false, { "original" })
-    vim.o.undolevels = vim.o.undolevels -- force undo break
+    api.nvim_buf_call(buf, function()
+        vim.o.undolevels = vim.o.undolevels -- force undo break in buf's context
+    end)
     api.nvim_buf_set_lines(buf, 0, -1, false, { "edit 1" })
-    vim.o.undolevels = vim.o.undolevels
+    api.nvim_buf_call(buf, function()
+        vim.o.undolevels = vim.o.undolevels
+    end)
     api.nvim_buf_set_lines(buf, 0, -1, false, { "edit 2" })
     return buf
 end
@@ -61,7 +65,7 @@ describe("undo / redo", function()
             local fn_undo, fn_redo
             for _, km in ipairs(keymaps) do
                 if km.lhs == "u" then fn_undo = km.callback end
-                if km.lhs == "<C-r>" then fn_redo = km.callback end
+                if km.lhs == "<C-r>" or km.lhs == "<C-R>" then fn_redo = km.callback end
             end
             assert.is_not_nil(fn_redo, "<C-r> keymap should be set on auto_diff_buf")
 


### PR DESCRIPTION
## Summary

- Adds `undo_step_back` (default: `u`) — undo one step in the attached buffer from the diff window
- Adds `undo_step_forward` (default: `<C-r>`) — redo one step from the diff window
- The tree refreshes automatically after each step so the highlighted current node stays in sync

Both actions are in the `auto_diff` keymap group and can be remapped like any other action.

## Tests

`tests/undo_step_spec.lua` — functional tests that open atone, invoke the keymap callbacks directly, and assert the buffer content changed; plus a config-defaults assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)