### PR TITLE
feat: add zoom_diff action to view diff in a centred float

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,16 +130,22 @@ require("atone").setup({
             goto_mark = { "'", "`" },
             mark_picker = "s",
             help = { "?", "g?" },
+            zoom_diff = "<leader>uz",
         },
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
+            zoom_diff = "<leader>uz",
         },
         help = {
             quit_help = { "<C-c>", "q" },
         },
+    },
+    zoom = {
+        width = 0.8,  -- fraction of editor width
+        height = 0.8, -- fraction of editor height
     },
     ui = {
         -- refer to `:h 'winborder'`
@@ -244,6 +250,7 @@ Here are the available actions and their default keybindings:
 | `mark_picker`      | `s`            | Open mark picker (fuzzy find).                                  |
 | `undo`             | `u`            | Undo one step in the attached buffer.                           |
 | `redo`             | `<C-r>`        | Redo one step in the attached buffer.                           |
+| `zoom_diff`   | `<leader>uz` (tree+diff) | Toggle a centred floating window showing the diff.       |
 | `quit`             | `<C-c>`, `q`   | Close all `atone.nvim` windows (tree, diff, and help).          |
 | `help`             | `?`, `g?`      | Show the help page.                                             |
 | `quit_help`        | `<C-c>`, `q`   | Close the help window.                                          |

--- a/README.md
+++ b/README.md
@@ -144,8 +144,12 @@ require("atone").setup({
         },
     },
     diff_float = {
-        width = 0.8,  -- fraction of editor width
-        height = 0.8, -- fraction of editor height
+        --- width of the diff float as a fraction of the editor width (0–1)
+        width = 0.8,
+        --- height of the diff float as a fraction of the editor height (0–1)
+        height = 0.8,
+        --- close the centred diff float when it loses focus.
+        autoclose = true,
     },
     ui = {
         -- refer to `:h 'winborder'`
@@ -250,7 +254,7 @@ Here are the available actions and their default keybindings:
 | `mark_picker`      | `s`            | Open mark picker (fuzzy find).                                  |
 | `undo`             | `u`            | Undo one step in the attached buffer.                           |
 | `redo`             | `<C-r>`        | Redo one step in the attached buffer.                           |
-| `float_diff`   | `gd` (tree+diff) | Toggle a centred floating window showing the diff.       |
+| `float_diff`       | `gd`           | Toggle a centred floating diff window.                          |
 | `quit`             | `<C-c>`, `q`   | Close all `atone.nvim` windows (tree, diff, and help).          |
 | `help`             | `?`, `g?`      | Show the help page.                                             |
 | `quit_help`        | `<C-c>`, `q`   | Close the help window.                                          |

--- a/README.md
+++ b/README.md
@@ -130,20 +130,20 @@ require("atone").setup({
             goto_mark = { "'", "`" },
             mark_picker = "s",
             help = { "?", "g?" },
-            zoom_diff = "<leader>uz",
+            float_diff = "gd",
         },
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
-            zoom_diff = "<leader>uz",
+            float_diff = "gd",
         },
         help = {
             quit_help = { "<C-c>", "q" },
         },
     },
-    zoom = {
+    diff_float = {
         width = 0.8,  -- fraction of editor width
         height = 0.8, -- fraction of editor height
     },
@@ -250,7 +250,7 @@ Here are the available actions and their default keybindings:
 | `mark_picker`      | `s`            | Open mark picker (fuzzy find).                                  |
 | `undo`             | `u`            | Undo one step in the attached buffer.                           |
 | `redo`             | `<C-r>`        | Redo one step in the attached buffer.                           |
-| `zoom_diff`   | `<leader>uz` (tree+diff) | Toggle a centred floating window showing the diff.       |
+| `float_diff`   | `gd` (tree+diff) | Toggle a centred floating window showing the diff.       |
 | `quit`             | `<C-c>`, `q`   | Close all `atone.nvim` windows (tree, diff, and help).          |
 | `help`             | `?`, `g?`      | Show the help page.                                             |
 | `quit_help`        | `<C-c>`, `q`   | Close the help window.                                          |

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -68,10 +68,12 @@ M.opts = {
         },
     },
     diff_float = {
-        --- Width of the diff float as a fraction of the editor width (0–1)
+        --- width of the diff float as a fraction of the editor width (0–1)
         width = 0.8,
-        --- Height of the diff float as a fraction of the editor height (0–1)
+        --- height of the diff float as a fraction of the editor height (0–1)
         height = 0.8,
+        --- close the centred diff float when it loses focus.
+        autoclose = true,
     },
     ui = {
         -- refer to `:h 'winborder'`

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -54,16 +54,24 @@ M.opts = {
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
+            zoom_diff = "<leader>uz",
         },
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
+            zoom_diff = "<leader>uz",
         },
         help = {
             quit_help = { "<C-c>", "q" },
         },
+    },
+    zoom = {
+        --- Width of the zoom float as a fraction of the editor width (0–1)
+        width = 0.8,
+        --- Height of the zoom float as a fraction of the editor height (0–1)
+        height = 0.8,
     },
     ui = {
         -- refer to `:h 'winborder'`

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -54,23 +54,23 @@ M.opts = {
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
-            zoom_diff = "<leader>uz",
+            float_diff = "gd",
         },
         auto_diff = {
             quit = { "<C-c>", "q" },
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
-            zoom_diff = "<leader>uz",
+            float_diff = "gd",
         },
         help = {
             quit_help = { "<C-c>", "q" },
         },
     },
-    zoom = {
-        --- Width of the zoom float as a fraction of the editor width (0–1)
+    diff_float = {
+        --- Width of the diff float as a fraction of the editor width (0–1)
         width = 0.8,
-        --- Height of the zoom float as a fraction of the editor height (0–1)
+        --- Height of the diff float as a fraction of the editor height (0–1)
         height = 0.8,
     },
     ui = {

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -237,15 +237,17 @@ local mappings = {
             end
             local w = math.floor(vim.o.columns * config.opts.diff_float.width)
             local h = math.floor(vim.o.lines * config.opts.diff_float.height)
-            M._float_diff_win = api.nvim_open_win(M._auto_diff_buf, true, {
-                relative = "editor",
-                row = math.floor((vim.o.lines - h) / 2),
-                col = math.floor((vim.o.columns - w) / 2),
-                width = w,
-                height = h,
-                style = "minimal",
-                border = config.opts.ui.border,
-                zindex = 100,
+            M._float_diff_win = utils.new_win("float", M._auto_diff_buf, {
+                win_config = {
+                    relative = "editor",
+                    row = math.floor((vim.o.lines - h) / 2),
+                    col = math.floor((vim.o.columns - w) / 2),
+                    width = w,
+                    height = h,
+                    style = "minimal",
+                    border = config.opts.ui.border,
+                    zindex = 100,
+                },
             })
             -- "q" closes diff_float and restores the quit mapping
             utils.keymap("n", "q", function()

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -13,7 +13,7 @@ local M = {
     _tree_win = nil,
     _float_win = nil,
     _diff_win = nil,
-    _zoom_win = nil,
+    _float_diff_win = nil,
     _tree_buf = nil,
     _help_buf = nil,
     _auto_diff_buf = nil,
@@ -225,19 +225,19 @@ local mappings = {
         end,
         "Open mark picker",
     },
-    zoom_diff = {
+    float_diff = {
         function()
-            if utils.win_exists(M._zoom_win) then
-                api.nvim_win_close(M._zoom_win, true)
-                M._zoom_win = nil
+            if utils.win_exists(M._float_diff_win) then
+                api.nvim_win_close(M._float_diff_win, true)
+                M._float_diff_win = nil
                 return
             end
             if not M._auto_diff_buf or not api.nvim_buf_is_valid(M._auto_diff_buf) then
                 return
             end
-            local w = math.floor(vim.o.columns * config.opts.zoom.width)
-            local h = math.floor(vim.o.lines * config.opts.zoom.height)
-            M._zoom_win = api.nvim_open_win(M._auto_diff_buf, true, {
+            local w = math.floor(vim.o.columns * config.opts.diff_float.width)
+            local h = math.floor(vim.o.lines * config.opts.diff_float.height)
+            M._float_diff_win = api.nvim_open_win(M._auto_diff_buf, true, {
                 relative = "editor",
                 row = math.floor((vim.o.lines - h) / 2),
                 col = math.floor((vim.o.columns - w) / 2),
@@ -247,23 +247,23 @@ local mappings = {
                 border = config.opts.ui.border,
                 zindex = 100,
             })
-            -- "q" closes the zoom float and restores the quit mapping
+            -- "q" closes diff_float and restores the quit mapping
             utils.keymap("n", "q", function()
-                api.nvim_win_close(M._zoom_win, true)
-                M._zoom_win = nil
+                api.nvim_win_close(M._float_diff_win, true)
+                M._float_diff_win = nil
             end, { buffer = M._auto_diff_buf, nowait = true })
             api.nvim_create_autocmd("WinClosed", {
-                pattern = tostring(M._zoom_win),
+                pattern = tostring(M._float_diff_win),
                 once = true,
                 callback = function()
-                    M._zoom_win = nil
+                    M._float_diff_win = nil
                     utils.keymap("n", "q", function()
                         M.close()
                     end, { buffer = M._auto_diff_buf })
                 end,
             })
         end,
-        "Toggle zoom: open the diff in a centred floating window",
+        "Toggle diff float: diff in a centred floating window",
     },
     undo = {
         function()
@@ -409,8 +409,8 @@ local function init()
         buffer = M._auto_diff_buf,
         group = M.augroup,
         callback = function()
-            -- Don't close atone when only the zoom float is being closed
-            if not M._zoom_win then
+            -- Don't close atone when only the diff float is being closed
+            if not M._float_diff_win then
                 M.close()
             end
         end,

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -249,21 +249,6 @@ local mappings = {
                     zindex = 100,
                 },
             })
-            -- "q" closes diff_float and restores the quit mapping
-            utils.keymap("n", "q", function()
-                api.nvim_win_close(M._float_diff_win, true)
-                M._float_diff_win = nil
-            end, { buffer = M._auto_diff_buf, nowait = true })
-            api.nvim_create_autocmd("WinClosed", {
-                pattern = tostring(M._float_diff_win),
-                once = true,
-                callback = function()
-                    M._float_diff_win = nil
-                    utils.keymap("n", "q", function()
-                        M.close()
-                    end, { buffer = M._auto_diff_buf })
-                end,
-            })
         end,
         "Toggle diff float: diff in a centred floating window",
     },
@@ -667,6 +652,7 @@ function M.close()
         pcall(api.nvim_win_close, M._tree_win, true)
         pcall(api.nvim_win_close, M._diff_win, true)
         pcall(api.nvim_win_close, M._float_win, true)
+        pcall(api.nvim_win_close, M._float_diff_win, true)
         pcall(api.nvim_win_close, M._dummy_win, true)
     end
 end

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -13,6 +13,7 @@ local M = {
     _tree_win = nil,
     _float_win = nil,
     _diff_win = nil,
+    _zoom_win = nil,
     _tree_buf = nil,
     _help_buf = nil,
     _auto_diff_buf = nil,
@@ -224,6 +225,46 @@ local mappings = {
         end,
         "Open mark picker",
     },
+    zoom_diff = {
+        function()
+            if utils.win_exists(M._zoom_win) then
+                api.nvim_win_close(M._zoom_win, true)
+                M._zoom_win = nil
+                return
+            end
+            if not M._auto_diff_buf or not api.nvim_buf_is_valid(M._auto_diff_buf) then
+                return
+            end
+            local w = math.floor(vim.o.columns * config.opts.zoom.width)
+            local h = math.floor(vim.o.lines * config.opts.zoom.height)
+            M._zoom_win = api.nvim_open_win(M._auto_diff_buf, true, {
+                relative = "editor",
+                row = math.floor((vim.o.lines - h) / 2),
+                col = math.floor((vim.o.columns - w) / 2),
+                width = w,
+                height = h,
+                style = "minimal",
+                border = config.opts.ui.border,
+                zindex = 100,
+            })
+            -- "q" closes the zoom float and restores the quit mapping
+            utils.keymap("n", "q", function()
+                api.nvim_win_close(M._zoom_win, true)
+                M._zoom_win = nil
+            end, { buffer = M._auto_diff_buf, nowait = true })
+            api.nvim_create_autocmd("WinClosed", {
+                pattern = tostring(M._zoom_win),
+                once = true,
+                callback = function()
+                    M._zoom_win = nil
+                    utils.keymap("n", "q", function()
+                        M.close()
+                    end, { buffer = M._auto_diff_buf })
+                end,
+            })
+        end,
+        "Toggle zoom: open the diff in a centred floating window",
+    },
     undo = {
         function()
             api.nvim_buf_call(M.attach_buf, function()
@@ -367,7 +408,12 @@ local function init()
     api.nvim_create_autocmd("WinClosed", {
         buffer = M._auto_diff_buf,
         group = M.augroup,
-        callback = M.close,
+        callback = function()
+            -- Don't close atone when only the zoom float is being closed
+            if not M._zoom_win then
+                M.close()
+            end
+        end,
     })
 
     api.nvim_create_autocmd({ "WinScrolled", "WinResized" }, {

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -13,10 +13,11 @@ local M = {
     _tree_win = nil,
     _float_win = nil,
     _diff_win = nil,
-    _float_diff_win = nil,
+    _centered_diff_win = nil,
     _tree_buf = nil,
     _help_buf = nil,
     _auto_diff_buf = nil,
+    _centered_diff_buf = nil,
     _dummy_win = nil,
     _dummy_buf = nil,
 }
@@ -63,6 +64,35 @@ local function get_seq_under_cursor()
         return nil
     end
     return tree.id_2seq(id)
+end
+
+---@param buf integer
+---@param diff_lines string[]
+local function render_diff_buf(buf, diff_lines)
+    utils.set_text(buf, diff_lines)
+    local lang = config.opts.diff_cur_node.treesitter and highlight.get_lang(M.attach_buf) or nil
+    local target_syntax = lang and "" or "diff"
+    if vim.bo[buf].syntax ~= target_syntax then
+        api.nvim_set_option_value("syntax", target_syntax, { buf = buf })
+    end
+    highlight.apply(buf, diff_lines, lang, {
+        treesitter = config.opts.diff_cur_node.treesitter,
+        inline_diff = config.opts.diff_cur_node.inline_diff,
+    })
+end
+
+---@param seq integer|nil
+local function update_diff_views(seq)
+    if not seq then
+        return
+    end
+    local diff_lines = diff.get_diff_by_seq(M.attach_buf, seq)
+    if config.opts.diff_cur_node.enabled then
+        render_diff_buf(M._auto_diff_buf, diff_lines)
+    end
+    if M._centered_diff_buf and api.nvim_buf_is_valid(M._centered_diff_buf) then
+        render_diff_buf(M._centered_diff_buf, diff_lines)
+    end
 end
 
 local used_mappings = {}
@@ -227,17 +257,18 @@ local mappings = {
     },
     float_diff = {
         function()
-            if utils.win_exists(M._float_diff_win) then
-                api.nvim_win_close(M._float_diff_win, true)
-                M._float_diff_win = nil
+            if utils.win_exists(M._centered_diff_win) then
+                api.nvim_win_close(M._centered_diff_win, true)
                 return
             end
-            if not M._auto_diff_buf or not api.nvim_buf_is_valid(M._auto_diff_buf) then
+            local seq = get_seq_under_cursor() or tree.cur_seq
+            if not seq or not (M._centered_diff_buf and api.nvim_buf_is_valid(M._centered_diff_buf)) then
                 return
             end
+            update_diff_views(seq)
             local w = math.floor(vim.o.columns * config.opts.diff_float.width)
             local h = math.floor(vim.o.lines * config.opts.diff_float.height)
-            M._float_diff_win = utils.new_win("float", M._auto_diff_buf, {
+            M._centered_diff_win = utils.new_win("float", M._centered_diff_buf, {
                 win_config = {
                     relative = "editor",
                     row = math.floor((vim.o.lines - h) / 2),
@@ -248,7 +279,9 @@ local mappings = {
                     border = config.opts.ui.border,
                     zindex = 100,
                 },
+                autoclose = config.opts.diff_float.autoclose,
             })
+            api.nvim_set_option_value("winhl", "Normal:NormalFloat", { win = M._centered_diff_win })
         end,
         "Toggle diff float: diff in a centred floating window",
     },
@@ -271,21 +304,6 @@ local mappings = {
         "Redo one step in the attached buffer",
     },
 }
-
---- Update the diff display buffer and apply the extra diff preview layers.
----@param diff_lines string[]
-local function update_diff_buf(diff_lines)
-    utils.set_text(M._auto_diff_buf, diff_lines)
-    local lang = config.opts.diff_cur_node.treesitter and highlight.get_lang(M.attach_buf) or nil
-    local target_syntax = lang and "" or "diff"
-    if vim.bo[M._auto_diff_buf].syntax ~= target_syntax then
-        api.nvim_set_option_value("syntax", target_syntax, { buf = M._auto_diff_buf })
-    end
-    highlight.apply(M._auto_diff_buf, diff_lines, lang, {
-        treesitter = config.opts.diff_cur_node.treesitter,
-        inline_diff = config.opts.diff_cur_node.inline_diff,
-    })
-end
 
 ---@param direction string
 ---@return string
@@ -316,14 +334,15 @@ local function compute_tree_width(lines)
     return fn.strdisplaywidth(first_line) + 10
 end
 
-local function uses_float_diff()
+---@return boolean?
+local function uses_floating_preview_diff()
     return config.opts.diff_cur_node.enabled and config.opts.diff_cur_node.width ~= "adaptive"
 end
 
 local function compute_diff_height()
     local height = api.nvim_win_get_height(M._tree_win)
 
-    if uses_float_diff() and utils.win_exists(M._dummy_win) then
+    if uses_floating_preview_diff() and utils.win_exists(M._dummy_win) then
         -- The hidden dummy split lives below the tree window and consumes one
         -- separator row, so include both pieces to recover the full column height.
         height = height + api.nvim_win_get_height(M._dummy_win) + 1
@@ -340,8 +359,8 @@ local function resize_tree_window(lines)
     api.nvim_win_set_width(M._tree_win, compute_tree_width(lines))
 end
 
-local function pos_float_diff_win()
-    if not M._show or not uses_float_diff() then
+local function pos_floating_preview_diff_win()
+    if not M._show or not uses_floating_preview_diff() then
         return
     end
     if not (utils.win_exists(M._tree_win) and utils.win_exists(M._diff_win) and utils.win_exists(M._dummy_win)) then
@@ -371,7 +390,7 @@ local function pos_float_diff_win()
 end
 
 local function init()
-    for _, buf_key in ipairs({ "tree_buf", "auto_diff_buf", "help_buf", "dummy_buf" }) do
+    for _, buf_key in ipairs({ "tree_buf", "auto_diff_buf", "centered_diff_buf", "help_buf", "dummy_buf" }) do
         local old_buf = M["_" .. buf_key]
         if old_buf and api.nvim_buf_is_valid(old_buf) then
             pcall(api.nvim_buf_delete, old_buf, { force = true })
@@ -380,6 +399,7 @@ local function init()
 
     M._tree_buf = utils.new_buf()
     M._auto_diff_buf = utils.new_buf()
+    M._centered_diff_buf = utils.new_buf()
     M._help_buf = utils.new_buf()
     M._dummy_buf = nil
 
@@ -388,10 +408,13 @@ local function init()
         group = M.augroup,
         callback = vim.schedule_wrap(function()
             local seq = get_seq_under_cursor()
-            if not seq or not config.opts.diff_cur_node.enabled then
+            if not seq then
                 return
             end
-            update_diff_buf(diff.get_diff_by_seq(M.attach_buf, seq))
+            if not config.opts.diff_cur_node.enabled and not utils.win_exists(M._centered_diff_win) then
+                return
+            end
+            update_diff_views(seq)
         end),
     })
 
@@ -403,12 +426,7 @@ local function init()
     api.nvim_create_autocmd("WinClosed", {
         buffer = M._auto_diff_buf,
         group = M.augroup,
-        callback = function()
-            -- Don't close atone when only the diff float is being closed
-            if not M._float_diff_win then
-                M.close()
-            end
-        end,
+        callback = M.close,
     })
 
     api.nvim_create_autocmd({ "WinScrolled", "WinResized" }, {
@@ -431,7 +449,7 @@ local function init()
             callback = function()
                 if M._show then
                     vim.schedule(function()
-                        pos_float_diff_win()
+                        pos_floating_preview_diff_win()
                     end)
                 end
             end,
@@ -459,6 +477,7 @@ local function check()
     if
         not (
             api.nvim_buf_is_valid(M._auto_diff_buf)
+            and api.nvim_buf_is_valid(M._centered_diff_buf)
             and api.nvim_buf_is_valid(M._tree_buf)
             and api.nvim_buf_is_valid(M._help_buf)
         )
@@ -467,7 +486,7 @@ local function check()
         return false
     end
 
-    if uses_float_diff() and not (M._dummy_buf and api.nvim_buf_is_valid(M._dummy_buf)) then
+    if uses_floating_preview_diff() and not (M._dummy_buf and api.nvim_buf_is_valid(M._dummy_buf)) then
         M.close()
         return false
     end
@@ -496,7 +515,7 @@ function M.open()
         local height = compute_diff_height()
         local diff_width_conf = config.opts.diff_cur_node.width
 
-        if uses_float_diff() then
+        if uses_floating_preview_diff() then
             local diff_width = diff_width_conf < 1 and math.floor(vim.o.columns * diff_width_conf + 0.5)
                 ---@diagnostic disable-next-line: param-type-mismatch
                 or math.floor(diff_width_conf)
@@ -593,7 +612,7 @@ function M.refresh(stay)
         resize_tree_window(buf_lines)
 
         if config.opts.diff_cur_node.width ~= "adaptive" then
-            pos_float_diff_win()
+            pos_floating_preview_diff_win()
         end
 
         if not stay then
@@ -611,9 +630,7 @@ function M.refresh(stay)
             tree.nodes[tree.cur_seq].depth * 2 - 1
         )
 
-        if config.opts.diff_cur_node.enabled then
-            update_diff_buf(diff.get_diff_by_seq(M.attach_buf, tree.cur_seq))
-        end
+        update_diff_views(get_seq_under_cursor() or tree.cur_seq)
     end
 end
 
@@ -660,8 +677,8 @@ function M.close()
         pcall(api.nvim_win_close, M._tree_win, true)
         pcall(api.nvim_win_close, M._diff_win, true)
         pcall(api.nvim_win_close, M._float_win, true)
-        pcall(api.nvim_win_close, M._float_diff_win, true)
         pcall(api.nvim_win_close, M._dummy_win, true)
+        pcall(api.nvim_win_close, M._centered_diff_win, true)
     end
 end
 

--- a/tests/zoom_diff_spec.lua
+++ b/tests/zoom_diff_spec.lua
@@ -35,10 +35,12 @@ describe("zoom_diff", function()
             assert.is_nil(core._zoom_win)
 
             -- trigger zoom_diff via keymap callback
+            -- nvim_buf_get_keymap returns the lhs with <leader> expanded to its value
+            local zoom_lhs = vim.keycode("<leader>uz")
             local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
             local fn_zoom
             for _, km in ipairs(keymaps) do
-                if km.lhs == "<leader>uz" then
+                if km.lhs == zoom_lhs then
                     fn_zoom = km.callback
                     break
                 end
@@ -57,10 +59,13 @@ describe("zoom_diff", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
+            local zoom_lhs = vim.keycode("<leader>uz")
             local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
             local fn_zoom
             for _, km in ipairs(keymaps) do
-                if km.lhs == "<leader>uz" then fn_zoom = km.callback end
+                if km.lhs == zoom_lhs then
+                    fn_zoom = km.callback
+                end
             end
             fn_zoom()
             local zoom_win = core._zoom_win
@@ -77,10 +82,13 @@ describe("zoom_diff", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
+            local zoom_lhs = vim.keycode("<leader>uz")
             local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
             local fn_zoom
             for _, km in ipairs(keymaps) do
-                if km.lhs == "<leader>uz" then fn_zoom = km.callback end
+                if km.lhs == zoom_lhs then
+                    fn_zoom = km.callback
+                end
             end
             fn_zoom()
             assert.is_true(core._show)

--- a/tests/zoom_diff_spec.lua
+++ b/tests/zoom_diff_spec.lua
@@ -1,0 +1,99 @@
+---@diagnostic disable: undefined-global, undefined-field
+local atone = require("atone")
+local core = require("atone.core")
+local config = require("atone.config")
+local api = vim.api
+
+local function make_buf()
+    local buf = api.nvim_create_buf(false, true)
+    vim.bo[buf].buftype = ""
+    vim.bo[buf].modifiable = true
+    vim.bo[buf].swapfile = false
+    api.nvim_buf_set_lines(buf, 0, -1, false, { "hello" })
+    return buf
+end
+
+describe("zoom_diff", function()
+    before_each(function()
+        atone.setup({ diff_cur_node = { enabled = true } })
+    end)
+
+    after_each(function()
+        if core._show then
+            core.close()
+        end
+        if core._zoom_win and api.nvim_win_is_valid(core._zoom_win) then
+            api.nvim_win_close(core._zoom_win, true)
+            core._zoom_win = nil
+        end
+    end)
+
+    it("opens a float showing _auto_diff_buf", function()
+        local buf = make_buf()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            assert.is_nil(core._zoom_win)
+
+            -- trigger zoom_diff via keymap callback
+            local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
+            local fn_zoom
+            for _, km in ipairs(keymaps) do
+                if km.lhs == "<leader>uz" then
+                    fn_zoom = km.callback
+                    break
+                end
+            end
+            assert.is_not_nil(fn_zoom, "<leader>uz keymap should be set on tree buf")
+            fn_zoom()
+
+            assert.is_not_nil(core._zoom_win)
+            assert.is_true(api.nvim_win_is_valid(core._zoom_win))
+            assert.are.equal(core._auto_diff_buf, api.nvim_win_get_buf(core._zoom_win))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("closes the zoom float on second call (toggle)", function()
+        local buf = make_buf()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
+            local fn_zoom
+            for _, km in ipairs(keymaps) do
+                if km.lhs == "<leader>uz" then fn_zoom = km.callback end
+            end
+            fn_zoom()
+            local zoom_win = core._zoom_win
+            assert.is_true(api.nvim_win_is_valid(zoom_win))
+
+            fn_zoom() -- toggle off
+            assert.is_false(api.nvim_win_is_valid(zoom_win))
+            assert.is_nil(core._zoom_win)
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("closing the zoom float does not close the atone layout", function()
+        local buf = make_buf()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
+            local fn_zoom
+            for _, km in ipairs(keymaps) do
+                if km.lhs == "<leader>uz" then fn_zoom = km.callback end
+            end
+            fn_zoom()
+            assert.is_true(core._show)
+
+            api.nvim_win_close(core._zoom_win, true) -- close float directly
+            assert.is_true(core._show, "atone layout should still be open")
+            assert.is_true(api.nvim_win_is_valid(core._diff_win))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("default zoom size config is 0.8 x 0.8", function()
+        assert.are.equal(0.8, config.opts.zoom.width)
+        assert.are.equal(0.8, config.opts.zoom.height)
+    end)
+end)

--- a/tests/zoom_diff_spec.lua
+++ b/tests/zoom_diff_spec.lua
@@ -13,7 +13,7 @@ local function make_buf()
     return buf
 end
 
-describe("zoom_diff", function()
+describe("float_diff", function()
     before_each(function()
         atone.setup({ diff_cur_node = { enabled = true } })
     end)
@@ -22,9 +22,9 @@ describe("zoom_diff", function()
         if core._show then
             core.close()
         end
-        if core._zoom_win and api.nvim_win_is_valid(core._zoom_win) then
-            api.nvim_win_close(core._zoom_win, true)
-            core._zoom_win = nil
+        if core._float_diff_win and api.nvim_win_is_valid(core._float_diff_win) then
+            api.nvim_win_close(core._float_diff_win, true)
+            core._float_diff_win = nil
         end
     end)
 
@@ -32,76 +32,76 @@ describe("zoom_diff", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
-            assert.is_nil(core._zoom_win)
+            assert.is_nil(core._float_diff_win)
 
-            -- trigger zoom_diff via keymap callback
+            -- trigger float_diff via keymap callback
             -- nvim_buf_get_keymap returns the lhs with <leader> expanded to its value
-            local zoom_lhs = vim.keycode("<leader>uz")
+            local diff_float_lhs = vim.keycode("gd")
             local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
-            local fn_zoom
+            local fd_diff_float
             for _, km in ipairs(keymaps) do
-                if km.lhs == zoom_lhs then
-                    fn_zoom = km.callback
+                if km.lhs == diff_float_lhs then
+                    fd_diff_float = km.callback
                     break
                 end
             end
-            assert.is_not_nil(fn_zoom, "<leader>uz keymap should be set on tree buf")
-            fn_zoom()
+            assert.is_not_nil(fd_diff_float, "gd keymap should be set on tree buf")
+            fd_diff_float()
 
-            assert.is_not_nil(core._zoom_win)
-            assert.is_true(api.nvim_win_is_valid(core._zoom_win))
-            assert.are.equal(core._auto_diff_buf, api.nvim_win_get_buf(core._zoom_win))
+            assert.is_not_nil(core._float_diff_win)
+            assert.is_true(api.nvim_win_is_valid(core._float_diff_win))
+            assert.are.equal(core._auto_diff_buf, api.nvim_win_get_buf(core._float_diff_win))
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("closes the zoom float on second call (toggle)", function()
+    it("closes the diff float on second call (toggle)", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
-            local zoom_lhs = vim.keycode("<leader>uz")
+            local diff_float_lhs = vim.keycode("gd")
             local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
-            local fn_zoom
+            local fd_diff_float
             for _, km in ipairs(keymaps) do
-                if km.lhs == zoom_lhs then
-                    fn_zoom = km.callback
+                if km.lhs == diff_float_lhs then
+                    fd_diff_float = km.callback
                 end
             end
-            fn_zoom()
-            local zoom_win = core._zoom_win
-            assert.is_true(api.nvim_win_is_valid(zoom_win))
+            fd_diff_float()
+            local diff_float_win = core._float_diff_win
+            assert.is_true(api.nvim_win_is_valid(diff_float_win))
 
-            fn_zoom() -- toggle off
-            assert.is_false(api.nvim_win_is_valid(zoom_win))
-            assert.is_nil(core._zoom_win)
+            fd_diff_float() -- toggle off
+            assert.is_false(api.nvim_win_is_valid(diff_float_win))
+            assert.is_nil(core._float_diff_win)
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("closing the zoom float does not close the atone layout", function()
+    it("closing the diff float does not close the atone layout", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
-            local zoom_lhs = vim.keycode("<leader>uz")
+            local diff_float_lhs = vim.keycode("gd")
             local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
-            local fn_zoom
+            local fd_diff_float
             for _, km in ipairs(keymaps) do
-                if km.lhs == zoom_lhs then
-                    fn_zoom = km.callback
+                if km.lhs == diff_float_lhs then
+                    fd_diff_float = km.callback
                 end
             end
-            fn_zoom()
+            fd_diff_float()
             assert.is_true(core._show)
 
-            api.nvim_win_close(core._zoom_win, true) -- close float directly
+            api.nvim_win_close(core._float_diff_win, true) -- close float directly
             assert.is_true(core._show, "atone layout should still be open")
             assert.is_true(api.nvim_win_is_valid(core._diff_win))
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("default zoom size config is 0.8 x 0.8", function()
-        assert.are.equal(0.8, config.opts.zoom.width)
-        assert.are.equal(0.8, config.opts.zoom.height)
+    it("default diff float size config is 0.8 x 0.8", function()
+        assert.are.equal(0.8, config.opts.diff_float.width)
+        assert.are.equal(0.8, config.opts.diff_float.height)
     end)
 end)

--- a/tests/zoom_diff_spec.lua
+++ b/tests/zoom_diff_spec.lua
@@ -13,6 +13,16 @@ local function make_buf()
     return buf
 end
 
+local function get_keymap_callback(buf, lhs)
+    local keymaps = api.nvim_buf_get_keymap(buf, "n")
+    local target = vim.keycode(lhs)
+    for _, km in ipairs(keymaps) do
+        if km.lhs == target then
+            return km.callback
+        end
+    end
+end
+
 describe("float_diff", function()
     before_each(function()
         atone.setup({ diff_cur_node = { enabled = true } })
@@ -22,86 +32,160 @@ describe("float_diff", function()
         if core._show then
             core.close()
         end
-        if core._float_diff_win and api.nvim_win_is_valid(core._float_diff_win) then
-            api.nvim_win_close(core._float_diff_win, true)
-            core._float_diff_win = nil
+        if core._centered_diff_win and api.nvim_win_is_valid(core._centered_diff_win) then
+            api.nvim_win_close(core._centered_diff_win, true)
         end
     end)
 
-    it("opens a float showing _auto_diff_buf", function()
+    it("opens a centred float with its own diff buffer", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
-            assert.is_nil(core._float_diff_win)
 
-            -- trigger float_diff via keymap callback
-            -- nvim_buf_get_keymap returns the lhs with <leader> expanded to its value
-            local diff_float_lhs = vim.keycode("gd")
-            local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
-            local fd_diff_float
-            for _, km in ipairs(keymaps) do
-                if km.lhs == diff_float_lhs then
-                    fd_diff_float = km.callback
-                    break
-                end
-            end
-            assert.is_not_nil(fd_diff_float, "gd keymap should be set on tree buf")
-            fd_diff_float()
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            assert.is_not_nil(open_float, "gd keymap should be set on tree buf")
+            open_float()
 
-            assert.is_not_nil(core._float_diff_win)
-            assert.is_true(api.nvim_win_is_valid(core._float_diff_win))
-            assert.are.equal(core._auto_diff_buf, api.nvim_win_get_buf(core._float_diff_win))
+            assert.is_true(api.nvim_win_is_valid(core._centered_diff_win))
+            assert.are.equal(core._centered_diff_buf, api.nvim_win_get_buf(core._centered_diff_win))
+            assert.are_not.equal(core._auto_diff_buf, core._centered_diff_buf)
+            assert.is_true(#api.nvim_buf_get_lines(core._centered_diff_buf, 0, -1, false) > 0)
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("closes the diff float on second call (toggle)", function()
+    it("opens from the diff window and keeps float highlighting", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
-            local diff_float_lhs = vim.keycode("gd")
-            local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
-            local fd_diff_float
-            for _, km in ipairs(keymaps) do
-                if km.lhs == diff_float_lhs then
-                    fd_diff_float = km.callback
-                end
-            end
-            fd_diff_float()
-            local diff_float_win = core._float_diff_win
+            api.nvim_set_current_win(core._diff_win)
+
+            local open_float = get_keymap_callback(core._auto_diff_buf, "gd")
+            assert.is_not_nil(open_float, "gd keymap should be set on diff buf")
+            open_float()
+
+            assert.are.equal("Normal:NormalFloat", api.nvim_get_option_value("winhl", { win = core._centered_diff_win }))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("toggles off on second gd", function()
+        local buf = make_buf()
+        api.nvim_buf_call(buf, function()
+            core.open()
+
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            open_float()
+            local diff_float_win = core._centered_diff_win
             assert.is_true(api.nvim_win_is_valid(diff_float_win))
 
-            fd_diff_float() -- toggle off
+            open_float()
             assert.is_false(api.nvim_win_is_valid(diff_float_win))
-            assert.is_nil(core._float_diff_win)
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("closing the diff float does not close the atone layout", function()
+    it("closing the centred float does not close the atone layout", function()
         local buf = make_buf()
         api.nvim_buf_call(buf, function()
             core.open()
-            local diff_float_lhs = vim.keycode("gd")
-            local keymaps = api.nvim_buf_get_keymap(core._tree_buf, "n")
-            local fd_diff_float
-            for _, km in ipairs(keymaps) do
-                if km.lhs == diff_float_lhs then
-                    fd_diff_float = km.callback
-                end
-            end
-            fd_diff_float()
-            assert.is_true(core._show)
 
-            api.nvim_win_close(core._float_diff_win, true) -- close float directly
-            assert.is_true(core._show, "atone layout should still be open")
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            open_float()
+
+            api.nvim_win_close(core._centered_diff_win, true)
+
+            assert.is_true(core._show)
+            assert.is_true(api.nvim_win_is_valid(core._tree_win))
             assert.is_true(api.nvim_win_is_valid(core._diff_win))
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("default diff float size config is 0.8 x 0.8", function()
-        assert.are.equal(0.8, config.opts.diff_float.width)
-        assert.are.equal(0.8, config.opts.diff_float.height)
+    it("closing the main diff window still closes the atone layout", function()
+        local buf = make_buf()
+        api.nvim_buf_call(buf, function()
+            core.open()
+
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            open_float()
+            api.nvim_win_close(core._diff_win, true)
+
+            assert.is_false(core._show)
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("autocloses the centred float by default", function()
+        local buf = make_buf()
+        api.nvim_buf_call(buf, function()
+            core.open()
+
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            open_float()
+            local diff_float_win = core._centered_diff_win
+            assert.is_true(api.nvim_win_is_valid(diff_float_win))
+
+            api.nvim_set_current_win(core._tree_win)
+            vim.wait(100, function()
+                return not api.nvim_win_is_valid(diff_float_win)
+            end)
+
+            assert.is_false(api.nvim_win_is_valid(diff_float_win))
+            assert.is_true(core._show)
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("can open centred diff even when auto diff is disabled", function()
+        local buf = make_buf()
+        atone.setup({ diff_cur_node = { enabled = false } })
+
+        api.nvim_buf_call(buf, function()
+            core.open()
+
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            open_float()
+
+            assert.is_true(api.nvim_win_is_valid(core._centered_diff_win))
+            assert.are.equal(core._centered_diff_buf, api.nvim_win_get_buf(core._centered_diff_win))
+            assert.is_true(#api.nvim_buf_get_lines(core._centered_diff_buf, 0, -1, false) > 0)
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("keeps the centred float open when autoclose is disabled", function()
+        local buf = make_buf()
+        atone.setup({
+            diff_cur_node = { enabled = true },
+            diff_float = { autoclose = false },
+        })
+
+        api.nvim_buf_call(buf, function()
+            core.open()
+
+            local open_float = get_keymap_callback(core._tree_buf, "gd")
+            open_float()
+            local diff_float_win = core._centered_diff_win
+
+            api.nvim_set_current_win(core._tree_win)
+            vim.wait(100)
+
+            assert.is_true(api.nvim_win_is_valid(diff_float_win))
+            assert.are.equal(diff_float_win, core._centered_diff_win)
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("default diff float config uses 0.8 x 0.8 with autoclose enabled", function()
+        local prev = package.loaded["atone.config"]
+        package.loaded["atone.config"] = nil
+        local fresh_config = require("atone.config")
+
+        assert.are.equal(0.8, fresh_config.opts.diff_float.width)
+        assert.are.equal(0.8, fresh_config.opts.diff_float.height)
+        assert.is_true(fresh_config.opts.diff_float.autoclose)
+
+        package.loaded["atone.config"] = prev
     end)
 end)


### PR DESCRIPTION
## Summary

- Adds a `zoom_diff` keymap action (default: `<leader>uz`, available in both tree and diff windows) that opens the diff buffer in a large centred floating window
- Toggling the same key, or pressing `q`, closes the float
- Closing the zoom float does **not** tear down the rest of the atone layout (the `WinClosed` handler on `_auto_diff_buf` is guarded by `M._zoom_win`)
- Float dimensions are configurable via a new `zoom` config table (`zoom.width` / `zoom.height`, fractions of editor size, default 0.8)

## Implementation detail

Atone's `WinClosed` autocmd on `_auto_diff_buf` calls `M.close()` for any window showing that buffer. With the zoom float also showing `_auto_diff_buf`, closing it would wrongly close the whole layout. The fix: the callback now checks `M._zoom_win` and skips `M.close()` while the zoom is open.

## Tests

`tests/zoom_diff_spec.lua` — opens zoom, verifies the float shows the right buffer, tests toggle-close, verifies the layout survives float closure, and checks config defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)