### PR TITLE
feat: add sticky diff reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Here are the available actions and their default keybindings:
 | `delete_all_marks` | `dM`           | Delete all marks in current buffer.                             |
 | `goto_mark`        | `'`, `` ` ``   | Jump to a mark slot (0-9).                                      |
 | `mark_picker`      | `s`            | Open mark picker (fuzzy find).                                  |
+| `set_sticky_ref`   | `=`            | Toggle a sticky diff base.                                      |
 | `undo`             | `u`            | Undo one step in the attached buffer.                           |
 | `redo`             | `<C-r>`        | Redo one step in the attached buffer.                           |
 | `quit`             | `<C-c>`, `q`   | Close all `atone.nvim` windows (tree, diff, and help).          |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,13 @@ require("atone").setup({
             ---@param ctx AtoneNodeLabelContext
             ---@return AtoneNodeLabel
             formatter = function(ctx)
-                return string.format("[%d] %s %s", ctx.seq, ctx.h_time, ctx.bookmark or "")
+                return string.format(
+                    "[%d] %s %s%s",
+                    ctx.seq,
+                    ctx.h_time,
+                    ctx.bookmark or "",
+                    ctx.is_sticky_ref and " [=]" or ""
+                )
             end,
             extmark_opts = { strict = false },
         },
@@ -181,7 +187,8 @@ require("atone").setup({
             ---@param ctx AtoneNodeLabelContext
             ---@return AtoneNodeLabel
             formatter = function(ctx)
-                return string.format("[%d] %s %s", ctx.seq, ctx.h_time, ctx.bookmark or "")
+                local sticky = ctx.is_sticky_ref and " [=]" or ""
+                return string.format("[%d] %s %s%s", ctx.seq, ctx.h_time, ctx.bookmark or "", sticky)
             end,
         },
     },
@@ -190,14 +197,15 @@ require("atone").setup({
 
 Available fields on `ctx`:
 
-| Field        | Type                                   | Description                                 |
-| ---          | ---                                    | ---                                         |
-| `seq`        | `integer`                              | Undo sequence number of the node            |
-| `is_current` | `boolean`                              | Whether this node is the current undo state |
-| `time`       | `integer`                              | Raw timestamp from Neovim's undotree        |
-| `h_time`     | `string`                               | Human-readable time string                  |
-| `bookmark`   | `string?`                              | Bookmark label text, e.g. `{a}`             |
-| `diff`       | `{ added: integer, removed: integer }` | Added/removed line counts for the node      |
+| Field            | Type                                   | Description                                       |
+| ---              | ---                                    | ---                                               |
+| `seq`            | `integer`                              | Undo sequence number of the node                  |
+| `is_current`     | `boolean`                              | Whether this node is the current undo state       |
+| `is_sticky_ref`  | `boolean`                              | Whether this node is the pinned sticky diff base  |
+| `time`           | `integer`                              | Raw timestamp from Neovim's undotree              |
+| `h_time`         | `string`                               | Human-readable time string                        |
+| `bookmark`       | `string?`                              | Bookmark label text, e.g. `{a}`                   |
+| `diff`           | `{ added: integer, removed: integer }` | Added/removed line counts for the node            |
 
 Things to know:
 
@@ -213,7 +221,8 @@ Plain string example:
 
 ```lua
 formatter = function(ctx)
-    return string.format("[%d] %s %s", ctx.seq, ctx.h_time, ctx.bookmark or "")
+    local sticky = ctx.is_sticky_ref and " [=]" or ""
+    return string.format("[%d] %s %s%s", ctx.seq, ctx.h_time, ctx.bookmark or "", sticky)
 end
 ```
 
@@ -228,6 +237,8 @@ formatter = function(ctx)
         { ctx.h_time, "Comment" },
         ctx.bookmark and " " or "",
         { ctx.bookmark or "", "AtoneMark" },
+        ctx.is_sticky_ref and " " or "",
+        ctx.is_sticky_ref and { "[=]", "AtoneStickyRef" } or "",
     }
 end
 ```
@@ -269,6 +280,7 @@ Here are the available actions and their default keybindings:
 | `AtoneSeq`              | link to `Number`          | The sequence number of each node                  |
 | `AtoneSeqBracket`       | link to `Comment`         | The brackets surrounding the node sequence number |
 | `AtoneCurrentNode`      | link to `Keyword`         | The currently selected node in the undo tree      |
+| `AtoneStickyRef`        | link to `Debug`           | The pinned sticky diff reference node             |
 | `AtoneMark`             | link to `BookmarkSign`    | Mark labels on nodes                              |
 | `AtoneDiffAdd`          | link to `DiffAdd`         | Background for added lines in the diff preview    |
 | `AtoneDiffDelete`       | link to `DiffDelete`      | Background for removed lines in the diff preview  |

--- a/lua/atone/annotations.lua
+++ b/lua/atone/annotations.lua
@@ -23,6 +23,7 @@
 ---@class AtoneNodeLabelContext
 ---@field seq integer
 ---@field is_current boolean
+---@field is_sticky_ref boolean Whether this node is the pinned sticky diff reference
 ---@field time integer
 ---@field h_time string Time in a human-readable format
 ---@field bookmark string? Bookmark label text built by `mark.build_labels`

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -86,7 +86,13 @@ M.opts = {
             ---@param ctx AtoneNodeLabelContext
             ---@return AtoneNodeLabel
             formatter = function(ctx)
-                return string.format("[%d] %s %s", ctx.seq, ctx.h_time, ctx.bookmark or "")
+                return string.format(
+                    "[%d] %s %s%s",
+                    ctx.seq,
+                    ctx.h_time,
+                    ctx.bookmark or "",
+                    ctx.is_sticky_ref and " [=]" or ""
+                )
             end,
             extmark_opts = { strict = false },
         },

--- a/lua/atone/config.lua
+++ b/lua/atone/config.lua
@@ -54,6 +54,7 @@ M.opts = {
             help = { "?", "g?" },
             undo = "u",
             redo = "<C-r>",
+            set_sticky_ref = "=",
         },
         auto_diff = {
             quit = { "<C-c>", "q" },

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -639,6 +639,7 @@ function M.open()
             fn.matchadd("AtoneSeqBracket", [=[\v\[\d+\]]=])
             fn.matchadd("AtoneSeq", [=[\v\[\zs\d+\ze\]]=])
             fn.matchadd("AtoneMark", [=[\v\{[^}]+\}]=])
+            fn.matchadd("AtoneStickyRef", [=[\v\[\=\]]=])
         end)
     end
     M.refresh()
@@ -654,7 +655,7 @@ function M.refresh(stay)
         local filepath = utils.buf_filepath(M.attach_buf)
         mark.prune(filepath, tree.nodes)
         local marks_labels = mark.build_labels(filepath)
-        local buf_lines = tree.render(marks_labels)
+        local buf_lines = tree.render(marks_labels, M._sticky_ref)
         utils.set_text(M._tree_buf, buf_lines)
         api.nvim_buf_clear_namespace(M._tree_buf, api.nvim_create_namespace("atone"), 0, -1)
         if config.opts.ui.node_label.custom then
@@ -739,6 +740,7 @@ end
 function M.close()
     if M._show then
         M._show = false
+        M._sticky_ref = nil
         pcall(api.nvim_win_close, M._tree_win, true)
         pcall(api.nvim_win_close, M._diff_win, true)
         pcall(api.nvim_win_close, M._float_win, true)

--- a/lua/atone/core.lua
+++ b/lua/atone/core.lua
@@ -18,6 +18,7 @@ local M = {
     _auto_diff_buf = nil,
     _dummy_win = nil,
     _dummy_buf = nil,
+    _sticky_ref = nil,
 }
 
 local _resize_autocmd_registered = false
@@ -224,6 +225,21 @@ local mappings = {
         end,
         "Open mark picker",
     },
+    set_sticky_ref = {
+        function()
+            if M._sticky_ref ~= nil then
+                M._sticky_ref = nil
+            else
+                local seq = get_seq_under_cursor()
+                if not seq then
+                    return
+                end
+                M._sticky_ref = seq
+            end
+            M.refresh(true)
+        end,
+        "Set/clear sticky diff reference (diff always computed against this node)",
+    },
     undo = {
         function()
             api.nvim_buf_call(M.attach_buf, function()
@@ -244,9 +260,22 @@ local mappings = {
     },
 }
 
+--- Get diff lines for a node, using the sticky ref as base when set.
+---@param seq integer
+---@return string[]
+local function get_diff_for_seq(seq)
+    if M._sticky_ref ~= nil then
+        local old = diff.get_context_by_seq(M.attach_buf, M._sticky_ref)
+        local new = diff.get_context_by_seq(M.attach_buf, seq)
+        return diff.get_diff(old, new)
+    end
+    return diff.get_diff_by_seq(M.attach_buf, seq)
+end
+
 --- Update the diff display buffer and apply the extra diff preview layers.
 ---@param diff_lines string[]
-local function update_diff_buf(diff_lines)
+---@param seq integer the sequence number being shown (used for sticky-ref header)
+local function update_diff_buf(diff_lines, seq)
     utils.set_text(M._auto_diff_buf, diff_lines)
     local lang = config.opts.diff_cur_node.treesitter and highlight.get_lang(M.attach_buf) or nil
     local target_syntax = lang and "" or "diff"
@@ -257,6 +286,22 @@ local function update_diff_buf(diff_lines)
         treesitter = config.opts.diff_cur_node.treesitter,
         inline_diff = config.opts.diff_cur_node.inline_diff,
     })
+    local ns = api.nvim_create_namespace("atone_diff_header")
+    api.nvim_buf_clear_namespace(M._auto_diff_buf, ns, 0, -1)
+    if M._sticky_ref ~= nil and seq ~= nil then
+        local header = string.format("[%d] → [%d]", M._sticky_ref, seq)
+        -- Prepend as a real line; existing highlight extmarks shift automatically
+        utils.set_text(M._auto_diff_buf, { header }, 0, 0)
+        api.nvim_buf_set_extmark(M._auto_diff_buf, ns, 0, 0, {
+            end_row = 0,
+            end_col = #header,
+            hl_group = "Comment",
+            hl_eol = true,
+        })
+        if M._diff_win and api.nvim_win_is_valid(M._diff_win) then
+            api.nvim_win_set_cursor(M._diff_win, { 1, 0 })
+        end
+    end
 end
 
 ---@param direction string
@@ -355,7 +400,7 @@ local function init()
             if not seq or not config.opts.diff_cur_node.enabled then
                 return
             end
-            update_diff_buf(diff.get_diff_by_seq(M.attach_buf, seq))
+            update_diff_buf(get_diff_for_seq(seq), seq)
         end),
     })
 
@@ -546,6 +591,7 @@ function M.refresh(stay)
         local marks_labels = mark.build_labels(filepath)
         local buf_lines = tree.render(marks_labels)
         utils.set_text(M._tree_buf, buf_lines)
+        api.nvim_buf_clear_namespace(M._tree_buf, api.nvim_create_namespace("atone"), 0, -1)
         if config.opts.ui.node_label.custom then
             tree.render_visible_labels(M._tree_buf, M._tree_win)
         end
@@ -570,8 +616,22 @@ function M.refresh(stay)
             tree.nodes[tree.cur_seq].depth * 2 - 1
         )
 
+        if M._sticky_ref and tree.nodes[M._sticky_ref] then
+            local sticky_id = tree.seq_2id(M._sticky_ref)
+            if sticky_id then
+                local sticky_lnum = compact and tree.total - sticky_id + 1 or (tree.total - sticky_id) * 2 + 1
+                utils.color_char(
+                    M._tree_buf,
+                    "AtoneStickyRef",
+                    buf_lines[sticky_lnum],
+                    sticky_lnum,
+                    tree.nodes[M._sticky_ref].depth * 2 - 1
+                )
+            end
+        end
+
         if config.opts.diff_cur_node.enabled then
-            update_diff_buf(diff.get_diff_by_seq(M.attach_buf, tree.cur_seq))
+            update_diff_buf(get_diff_for_seq(tree.cur_seq), tree.cur_seq)
         end
     end
 end

--- a/lua/atone/init.lua
+++ b/lua/atone/init.lua
@@ -9,6 +9,7 @@ local highlights = {
     CurrentNode = { link = "Keyword" },
     SeqBracket = { link = "Comment" },
     Mark = { link = "BookmarkSign" },
+    StickyRef = { link = "Debug" },
     DiffAdd = { link = "DiffAdd" },
     DiffDelete = { link = "DiffDelete" },
     DiffAddInline = { source = "DiffAdd" },

--- a/lua/atone/tree.lua
+++ b/lua/atone/tree.lua
@@ -52,6 +52,7 @@ local M = {
     -- update only the rows that actually contain nodes.
     lnum_to_seq = {},
     marks_labels = {},
+    sticky_ref = nil,
     total = 1,
     last_seq = 0,
     cur_seq = 0,
@@ -75,6 +76,7 @@ local function get_node_label(node)
     local ctx = {
         seq = node.seq,
         is_current = node.seq == M.cur_seq,
+        is_sticky_ref = node.seq == M.sticky_ref,
         time = node.time,
         h_time = get_h_time(node),
         bookmark = M.marks_labels[node.seq],
@@ -307,9 +309,10 @@ end
 -- o |  [1]   2    7  <- a node
 -- |/              8  <- line after this node
 -- o    [0]   1    9
-function M.render(marks_labels)
+function M.render(marks_labels, sticky_ref)
     marks_labels = marks_labels or {}
     M.marks_labels = marks_labels
+    M.sticky_ref = sticky_ref
     M.lines = {}
     M.lnum_to_seq = {}
     local max_depth = 1
@@ -425,10 +428,11 @@ function M.render(marks_labels)
             local seq = M.id_2seq(i)
             local lnum = compact and total - i + 1 or (total - i) * 2 + 1
             local node = M.nodes[seq]
+            local sticky = seq == M.sticky_ref and " [=]" or ""
             M.lines[lnum] = set_char_at(
                 M.lines[lnum],
                 label_col,
-                string.format("[%s] %s %s", seq, get_h_time(node), marks_labels[seq] or "")
+                string.format("[%s] %s %s%s", seq, get_h_time(node), marks_labels[seq] or "", sticky)
             )
         end
     end

--- a/tests/sticky_ref_spec.lua
+++ b/tests/sticky_ref_spec.lua
@@ -1,0 +1,103 @@
+---@diagnostic disable: undefined-global, undefined-field
+local diff = require("atone.diff")
+local tree = require("atone.tree")
+local utils = require("atone.utils")
+local api = vim.api
+
+--- Load a fixture into a scratch buffer and return (buf, sorted_seqs).
+local function load_fixture(file, undo_file)
+    local buf = utils.new_buf()
+    api.nvim_buf_call(buf, function()
+        vim.cmd.e(file)
+        vim.cmd("silent rundo " .. undo_file)
+        tree.convert(buf)
+    end)
+    local seqs = vim.tbl_keys(tree.nodes)
+    table.sort(seqs)
+    -- Remove seq 0 (the empty root), keep only real undo nodes
+    seqs = vim.tbl_filter(function(s) return s > 0 end, seqs)
+    return buf, seqs
+end
+
+describe("Sticky-ref diffing", function()
+    local buf, seqs
+
+    before_each(function()
+        buf, seqs = load_fixture("tests/test1", "tests/test1.undo")
+    end)
+
+    after_each(function()
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("get_context_by_seq returns content at the requested undo state", function()
+        -- Context at seq 0 (initial empty state) should differ from later states
+        local ctx_early = diff.get_context_by_seq(buf, seqs[1])
+        local ctx_later = diff.get_context_by_seq(buf, seqs[#seqs])
+        -- They should not be identical for a file with multiple changes
+        assert.is_not_nil(ctx_early)
+        assert.is_not_nil(ctx_later)
+        -- The two contexts are tables of lines
+        assert.is_true(type(ctx_early) == "table")
+        assert.is_true(type(ctx_later) == "table")
+    end)
+
+    it("get_diff between two arbitrary contexts reflects their exact difference", function()
+        -- This is the core operation the sticky-ref feature relies on:
+        -- diff.get_diff(get_context_by_seq(buf, ref), get_context_by_seq(buf, cur))
+        -- We test it directly with known content to avoid fixture-content fragility.
+        local ctx_old = { "alpha", "beta", "gamma" }
+        local ctx_new = { "alpha", "beta", "gamma", "delta", "epsilon" }
+        local d = diff.get_diff(ctx_old, ctx_new)
+
+        local added = {}
+        for _, l in ipairs(d) do
+            if l:sub(1, 1) == "+" then
+                table.insert(added, l:sub(2))
+            end
+        end
+        assert.are.same({ "delta", "epsilon" }, added)
+    end)
+
+    it("diff from a node to itself produces no changes", function()
+        local seq = seqs[1]
+        local ctx = diff.get_context_by_seq(buf, seq)
+        local d = diff.get_diff(ctx, ctx)
+        local has_change = false
+        for _, l in ipairs(d) do
+            if l:sub(1, 1) == "+" or l:sub(1, 1) == "-" then
+                has_change = true
+                break
+            end
+        end
+        assert.is_false(has_change, "diff from a node to itself should have no +/- lines")
+    end)
+end)
+
+describe("Sticky-ref toggle (core._sticky_ref)", function()
+    local core
+
+    before_each(function()
+        core = require("atone.core")
+        core._sticky_ref = nil
+    end)
+
+    after_each(function()
+        core._sticky_ref = nil
+    end)
+
+    it("is nil by default", function()
+        assert.is_nil(core._sticky_ref)
+    end)
+
+    it("can be set to a seq value", function()
+        core._sticky_ref = 5
+        assert.are.equal(5, core._sticky_ref)
+    end)
+
+    it("can be cleared back to nil", function()
+        core._sticky_ref = 5
+        core._sticky_ref = nil
+        assert.is_nil(core._sticky_ref)
+    end)
+end)

--- a/tests/sticky_ref_spec.lua
+++ b/tests/sticky_ref_spec.lua
@@ -15,7 +15,9 @@ local function load_fixture(file, undo_file)
     local seqs = vim.tbl_keys(tree.nodes)
     table.sort(seqs)
     -- Remove seq 0 (the empty root), keep only real undo nodes
-    seqs = vim.tbl_filter(function(s) return s > 0 end, seqs)
+    seqs = vim.tbl_filter(function(s)
+        return s > 0
+    end, seqs)
     return buf, seqs
 end
 

--- a/tests/sticky_ref_spec.lua
+++ b/tests/sticky_ref_spec.lua
@@ -162,4 +162,61 @@ describe("sticky ref", function()
         end)
         api.nvim_buf_delete(buf, { force = true })
     end)
+
+    it("shows [=] marker next to the sticky ref node label", function()
+        local buf = make_buf_with_history()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            local seqs = real_seqs()
+            local ref_seq = seqs[1]
+
+            core._sticky_ref = ref_seq
+            core.refresh(true)
+
+            local ref_lnum = seq_to_lnum(ref_seq)
+            local ref_line = api.nvim_buf_get_lines(core._tree_buf, ref_lnum - 1, ref_lnum, false)[1]
+            assert.is_truthy(ref_line:match("%[=%]"), ("sticky ref line should contain [=]: %q"):format(ref_line))
+
+            -- other nodes should not have the marker
+            local other_lnum = seq_to_lnum(seqs[#seqs])
+            local other_line = api.nvim_buf_get_lines(core._tree_buf, other_lnum - 1, other_lnum, false)[1]
+            assert.is_nil(other_line:match("%[=%]"))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("removes [=] marker when sticky ref is cleared", function()
+        local buf = make_buf_with_history()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            local seqs = real_seqs()
+            local ref_seq = seqs[1]
+            local ref_lnum = seq_to_lnum(ref_seq)
+
+            core._sticky_ref = ref_seq
+            core.refresh(true)
+            local with_marker = api.nvim_buf_get_lines(core._tree_buf, ref_lnum - 1, ref_lnum, false)[1]
+            assert.is_truthy(with_marker:match("%[=%]"))
+
+            core._sticky_ref = nil
+            core.refresh(true)
+            local without_marker = api.nvim_buf_get_lines(core._tree_buf, ref_lnum - 1, ref_lnum, false)[1]
+            assert.is_nil(without_marker:match("%[=%]"))
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("clears sticky ref on close", function()
+        local buf = make_buf_with_history()
+        api.nvim_buf_call(buf, function()
+            core.open()
+            local set_sticky = get_keymap_callback(core._tree_buf, "=")
+            set_sticky()
+            assert.is_not_nil(core._sticky_ref)
+
+            core.close()
+            assert.is_nil(core._sticky_ref)
+        end)
+        api.nvim_buf_delete(buf, { force = true })
+    end)
 end)

--- a/tests/tree_graph_spec.lua
+++ b/tests/tree_graph_spec.lua
@@ -210,7 +210,7 @@ describe("fixed label mode", function()
             ui = { compact = false, node_label = { custom = false } },
         })
 
-        eq(#info.matches, 3)
+        eq(#info.matches, 4)
     end)
 end)
 


### PR DESCRIPTION
## Summary

- Press `=` in the tree window to pin a node as the **sticky diff reference**. While set, the diff preview always shows the change from that node to the cursor — regardless of parent/child relationship.
- Press `=` again (from any position) to clear.
- The pinned node is highlighted with `AtoneStickyRef` (links to `Debug`).
- A `[old] → [new]` header appears at the top of the diff window while active.
- Fixes extmark accumulation: `nvim_buf_clear_namespace` is now called on each refresh so stale `color_char` highlights don't stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)